### PR TITLE
Increasing the amount of tries before it gives up on a running build

### DIFF
--- a/lib/atlas-api/client.rb
+++ b/lib/atlas-api/client.rb
@@ -22,7 +22,7 @@ module Atlas
           last_response = build(post_response.id)  
           break if last_response.status.find { |format| format.status == "queued" || format.status == "working" }.nil?
           tries += 1
-          if tries > 20
+          if tries > 100
             raise "The build is taking too long. Exiting"
           end
           sleep(5)


### PR DESCRIPTION
This increases the timeout to over 8 minutes, which should catch every legitimate build without being too onerous if there is indeed a real problem.