### PR TITLE
Updating rake to Patched Version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem "rake", "~> 10.1.0"
+gem "rake", "~> 13.0.1"
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,43 +1,52 @@
 PATH
   remote: .
   specs:
-    atlas-api (0.1.0)
+    atlas-api (0.1.2)
       faraday (~> 0.15.4)
       hashie (~> 3.6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.2.8)
-    crack (0.4.2)
-      safe_yaml (~> 1.0.0)
-    diff-lcs (1.2.5)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.5.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
+    hashdiff (1.0.1)
     hashie (3.6.0)
     multipart-post (2.1.1)
-    rake (10.1.1)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
-    safe_yaml (1.0.1)
-    webmock (1.17.4)
-      addressable (>= 2.2.7)
+    public_suffix (4.0.7)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   atlas-api!
-  rake (~> 10.1.0)
+  rake (~> 13.0.1)
   rspec
   webmock
 
 BUNDLED WITH
-   1.17.1
+   2.3.12

--- a/lib/atlas-api/version.rb
+++ b/lib/atlas-api/version.rb
@@ -1,5 +1,5 @@
 module Atlas
   module Api
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
Updating `rake` to a patched version, as originally flagged by Dependabot here: https://github.com/oreillymedia/atlas-api/pull/3

Creating a new PR as over two years have elapsed since the original Dependabot commit. I'll close that and link here once this is merged.