### PR TITLE
Security Patch: faraday 2.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.2', '3.1', '3.0', '2.7']
+        ruby-version: ['3.3.6']
 
     steps:
       - name: Check out code

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     atlas-api (0.2.0)
-      faraday (~> 2.7.0)
+      faraday (~> 2.14.0)
       hashie (~> 3.6.0)
 
 GEM
@@ -14,12 +14,18 @@ GEM
       rexml
     diff-lcs (1.5.0)
     docile (1.4.0)
-    faraday (2.7.0)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     hashdiff (1.0.1)
     hashie (3.6.0)
+    json (2.19.3)
+    logger (1.7.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     public_suffix (5.0.0)
     rake (13.0.6)
     rexml (3.4.2)
@@ -36,13 +42,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    ruby2_keywords (0.0.5)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    uri (1.1.1)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -59,4 +65,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.12
+   2.5.22

--- a/atlas-api.gemspec
+++ b/atlas-api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "faraday", "~> 2.7.0"
+  gem.add_dependency "faraday", "~> 2.14.0"
   gem.add_dependency "hashie", "~> 3.6.0"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "webmock"

--- a/lib/atlas-api/version.rb
+++ b/lib/atlas-api/version.rb
@@ -1,5 +1,5 @@
 module Atlas
   module Api
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
This is meant to resolve these alerts:

- https://github.com/oreillymedia/atlas-api/security/dependabot/10
- https://github.com/oreillymedia/atlas-api/security/dependabot/11

Needs to be done here because the Workers installs this Gem directly from GitHub.

Update: It seems this patch drops support for Ruby 2.7. I don't think that's important and frankly the only thing that really matters is support for the Ruby version in the Workers container. I've updated the CI to reflect that, but please let me know if you disagree.